### PR TITLE
build: auto-compile shaders before every run

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -48,3 +48,22 @@ target("curloz engine")
     if is_plat("linux") then
         add_syslinks("pthread", "dl")
     end
+
+    -- Compile all shaders in assets/shaders/ to SPIR-V before every run
+    before_run(function (target)
+        local shader_dir = path.join(os.projectdir(), "assets", "shaders")
+        local glslc = find_tool("glslc") or find_tool("glslangValidator")
+        if not glslc then
+            raise("Shader compiler not found. Please install glslc (Vulkan SDK) or glslangValidator.")
+        end
+        local exts = { ".vert", ".frag", ".comp", ".geom", ".tesc", ".tese" }
+        for _, ext in ipairs(exts) do
+            for _, src in ipairs(os.files(path.join(shader_dir, "*" .. ext))) do
+                -- e.g. assets/shaders/triangle_vert.vert -> assets/shaders/triangle_vert.spirv
+                local base = path.basename(src)
+                local spv  = path.join(shader_dir, base .. ".spirv")
+                print("Compiling shader: " .. path.filename(src) .. " -> " .. path.filename(spv))
+                os.vrunv(glslc.program, { src, "-o", spv })
+            end
+        end
+    end)


### PR DESCRIPTION
## Auto-compile shaders before every run

### Problem
Shader source files (`.vert`, `.frag`) were being compiled manually and the resulting `.spirv` binaries committed to the repo. Any change to a shader required a separate manual `glslc` invocation before running — easy to forget, and a source of stale-shader bugs.

### Solution
Added a `before_run` hook in `xmake.lua` that automatically recompiles all shaders in `assets/shaders/` to SPIR-V on every `xmake run`.

### Changes
- **`xmake.lua`** — added `before_run` hook inside the `curloz engine` target

### How it works
- Detects the shader compiler at runtime: prefers `glslc` (Vulkan SDK), falls back to `glslangValidator`
- Fails fast with a clear error if neither is found
- Globs all supported shader stages: `.vert`, `.frag`, `.comp`, `.geom`, `.tesc`, `.tese`
- Outputs `.spirv` files using the existing naming convention (e.g. `triangle_vert.vert → triangle_vert.spirv`)

### Why `before_run` and not `after_build`?
`after_build` only fires when C++ sources change. A shader-only edit would still require a manual compile step. `before_run` fires unconditionally on every `xmake run`, ensuring shaders are always fresh.

### Testing
- Modified a shader source and ran `xmake run` — recompilation triggered automatically
- Verified output `.spirv` files are updated
- Confirmed clean error message when `glslc` is not installed

### Notes
The pre-built `.spirv` files in `assets/shaders/` can now be removed from version control and added to `.gitignore` since they are generated artifacts.