### PR TITLE
docs: add Vulkan and build tool troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,57 @@
 # Curloz Engine
 
-A Vulkan 1.3 game engine written in C++23. 
-
+A Vulkan 1.3 game engine written in C++23.
 
 ## Tech Stack
 
-| System | Library        |
-|---|----------------|
-| Renderer | Vulkan 1.3     |
-| Windowing | GLFW           |
-| ECS | clz::ecs#      |
-| Physics | Jolt Physics*  |
-| Audio | OpenAL Soft*   |
-| Math | clz::math#     |
+| System        | Library        |
+| ------------- | -------------- |
+| Renderer      | Vulkan 1.3     |
+| Windowing     | GLFW           |
+| ECS           | clz::ecs#      |
+| Physics       | Jolt Physics*  |
+| Audio         | OpenAL Soft*   |
+| Math          | clz::math#     |
 | Model Loading | assimp         |
-| Animation | ozz-animation* |
-| Build System | CMake + Ninja  |
+| Animation     | ozz-animation* |
+| Build System  | CMake + Ninja  |
 
 ---
+
 > '#' Signifies that no external library is used and is self authorized
 
 > '*' Signifies that system is planned and has not yet been implemented yet, or needs further work
+
 ---
 
 ## Prerequisites
 
 ### Linux
-- Vulkan 1.3 capable GPU and drivers
-- CMake 3.25+
-- Ninja
-- clang-format (for code style enforcement)
-- GCC or Clang with C++23 support
+
+* Vulkan 1.3 capable GPU and drivers
+* CMake 3.25+
+* Ninja
+* clang-format (for code style enforcement)
+* GCC or Clang with C++23 support
 
 On Gentoo:
+
 ```bash
 sudo emerge -av cmake ninja clang dev-util/vulkan-tools
 ```
 
 On Ubuntu/Debian:
+
 ```bash
 sudo apt install cmake ninja-build clang-format vulkan-tools libvulkan-dev
 ```
 
 ### Windows
-- CMake 3.25+
-- Ninja
-- Vulkan SDK from [lunarg.com](https://vulkan.lunarg.com)
-- MSVC or MinGW with C++23 support
+
+* CMake 3.25+
+* Ninja
+* Vulkan SDK from [lunarg.com](https://vulkan.lunarg.com)
+* MSVC or MinGW with C++23 support
 
 ---
 
@@ -69,9 +74,72 @@ Binary lands at `build/debug/CurlozEngine`.
 
 ---
 
+## Build Troubleshooting
+
+If configuration or compilation fails, check the following common setup issues before opening a new issue.
+
+### Vulkan SDK is not detected
+
+The project uses CMake's Vulkan package discovery during configuration. If CMake reports that Vulkan could not be found, first verify that the Vulkan SDK and tools are available on your system.
+
+Check whether the Vulkan tools are accessible from the terminal:
+
+```bash
+vulkaninfo --summary
+```
+
+If the command is not found, verify that the Vulkan SDK is installed and that its tools are available through the system `PATH`.
+
+On Windows, verify that the Vulkan SDK environment variable is set:
+
+```powershell
+echo $env:VULKAN_SDK
+```
+
+The command should print the path to the installed Vulkan SDK. If it is empty, verify the SDK installation and environment configuration, then restart the terminal before running CMake again.
+
+After correcting the SDK setup, remove the previous build directory and configure the project again:
+
+```bash
+cmake -E remove_directory build/debug
+cmake -B build/debug -G Ninja
+```
+
+### CMake or Ninja is not available
+
+Verify that the required build tools are installed and accessible from the command line:
+
+```bash
+cmake --version
+ninja --version
+```
+
+The project requires CMake 3.25 or newer. If either command is not found, install the missing tool and reopen the terminal before configuring the project again.
+
+### CMake generator mismatch
+
+The documented build commands use the Ninja generator:
+
+```bash
+cmake -B build/debug -G Ninja
+cmake --build build/debug
+```
+
+A CMake build directory remembers the generator used when it was first configured. Reusing the same directory with a different generator may produce a generator mismatch error.
+
+Remove the existing build directory before configuring it again with Ninja:
+
+```bash
+cmake -E remove_directory build/debug
+cmake -B build/debug -G Ninja
+cmake --build build/debug
+```
+
+---
+
 ## Project Structure
 
-```
+```text
 curloz-engine/
 ├── src/                # Source files (.cpp)
 ├── include/            # Header files (.hpp)
@@ -79,10 +147,10 @@ curloz-engine/
 ├── assets/             # Models, textures, audio
 ├── external/           # Git submodules (do not modify manually)
 ├── core/               # Utility functions, basically helpers used in entire engine
-├── .clang-format	# clang-format configuration
-├── .editorconfig	# editorconfig configuration
-├── CMakeLists.txt	# CMake build configuration
-└── LICENSE		# License file
+├── .clang-format       # clang-format configuration
+├── .editorconfig       # editorconfig configuration
+├── CMakeLists.txt      # CMake build configuration
+└── LICENSE             # License file
 ```
 
 ---
@@ -94,7 +162,8 @@ Contributors are always welcome! If you feel there is any issue, or think there'
 If you think can handle a subsystem for long term, feel free to approach and it will be assigned to you.
 
 ### To-Do
-- Display model component's Node->Mesh->Primitives hierarchy in editor's inspector
+
+* Display model component's Node->Mesh->Primitives hierarchy in editor's inspector
 
 For More details, see the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 


### PR DESCRIPTION
## Related to issue #27

## Description

This PR adds build troubleshooting guidance for the Vulkan SDK and the CMake/Ninja build workflow.

### Changes

* Added steps to verify Vulkan tools and SDK environment configuration.
* Added CMake and Ninja availability checks.
* Documented the project's minimum CMake version requirement.
* Added guidance for resolving CMake generator mismatch errors.
* Added clean reconfiguration steps for stale or incorrectly configured build directories.

## Scope

This PR covers the Vulkan SDK and CMake/Ninja troubleshooting portion of issue #27. Other troubleshooting topics are being coordinated separately to avoid overlapping work.

## Screenshots
<img width="1292" height="883" alt="Screenshot 2026-07-04 150149" src="https://github.com/user-attachments/assets/bdad862a-9a4c-4cbb-b913-f84053c723cd" />
<img width="1286" height="948" alt="Screenshot 2026-07-04 150158" src="https://github.com/user-attachments/assets/2e6345f7-d3fe-487c-9ac0-6afd46a0392c" />
<img width="1274" height="332" alt="Screenshot 2026-07-04 150207" src="https://github.com/user-attachments/assets/272688d8-e278-46f0-b7f0-f086ce1b8e7e" />

## Testing

Documentation-only change.

* Reviewed all commands against the repository's current build instructions.
* Verified that the troubleshooting guidance matches the current CMake configuration and Ninja-based workflow.
* Reviewed Markdown formatting and code blocks.

### @curloz123 Kindly review my PR and merge it. 
**Jidnyasa Patil , ECSoC'26**