### PR TITLE
feature: document subsystem lifecycle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,150 @@ The main loop in main.cpp is the only place that knows about every subsystem at 
 Every subsystem's architecture and patterns
 ---
 
+## Subsystem Lifecycle
+
+Curloz Engine is organized as a set of independent subsystems. Each subsystem is responsible for a specific part of the engine and is coordinated from `src/main.cpp`.
+
+The engine lifecycle has three main phases:
+
+1. Initialization
+2. Per-frame update
+3. Shutdown
+
+Not every subsystem requires every lifecycle function. Some systems only perform initialization or shutdown work, while others participate in the main loop and update every frame.
+
+### Lifecycle Overview
+
+```text
+Initialization
+──────────────
+
+Config
+  ↓
+Time
+  ↓
+Window
+  ↓
+Renderer
+  ↓
+Audio
+  ↓
+Scene Load
+
+
+Main Loop
+─────────
+
+Compute Time
+  ↓
+Window Update
+  ↓
+Renderer Update
+  ↓
+Repeat until EngineState::Shutdown
+
+
+Shutdown
+────────
+
+Scene Save
+  ↓
+Audio Shutdown
+  ↓
+Renderer Shutdown
+  ↓
+Window Shutdown
+```
+
+### Initialization Order
+
+Subsystems are initialized in dependency order.
+
+The current startup flow in `src/main.cpp` is:
+
+```text
+Config → Time → Window → Renderer → Audio → Scene
+```
+
+The order matters because later systems may depend on state created by earlier systems.
+
+For example:
+
+* Configuration is initialized first because other parts of the engine read application configuration.
+* Time is initialized before entering the main loop.
+* The window is initialized before the renderer because rendering requires a valid windowing environment.
+* Audio is initialized after the renderer.
+* Scene data is loaded after the core runtime systems are available.
+
+When adding a subsystem, determine its dependencies before choosing where its initialization belongs.
+
+### Per-Frame Update Flow
+
+After initialization and scene loading complete, the engine enters the main loop.
+
+The current update order is:
+
+```text
+Time → Window → Renderer
+```
+
+Conceptually, each frame performs:
+
+```cpp
+while (clz::state::g_engineState != clz::state::EngineState::Shutdown)
+{
+	clz::time::computeTime();
+	clz::window::update();
+	clz::renderer::update();
+}
+```
+
+The loop continues until the global engine state changes to `EngineState::Shutdown`.
+
+Not every subsystem needs a per-frame update. A subsystem should only participate in the main loop when it has work that must be performed every frame.
+
+### Shutdown Order
+
+The current shutdown flow is:
+
+```text
+Scene Save → Audio → Renderer → Window
+```
+
+Scene state is saved before runtime systems are destroyed. Audio is shut down before the renderer and window, and the window is destroyed after the renderer has finished using it.
+
+When adding shutdown logic, consider dependencies carefully. A subsystem should not attempt to use another subsystem that has already been destroyed.
+
+### Subsystem Boundaries
+
+Subsystems should remain independent and communicate through clearly defined interfaces.
+
+A subsystem should:
+
+* own the state related to its responsibility;
+* expose only the operations and data required by other systems;
+* avoid directly managing another subsystem's internal state;
+* avoid unnecessary dependencies on unrelated systems;
+* be initialized, updated, and shut down from the central engine flow when lifecycle coordination is required.
+
+For example, the renderer should not become responsible for ECS behavior. It may consume the render data required to draw entities, but entity-management responsibilities should remain outside the renderer.
+
+This separation keeps subsystems easier to understand, test, modify, and replace without creating unnecessary coupling.
+
+### Adding a New Subsystem
+
+Before adding a new subsystem to the engine lifecycle:
+
+1. Define what the subsystem owns.
+2. Identify which existing systems it depends on.
+3. Place initialization after its required dependencies.
+4. Add a per-frame update only when continuous processing is necessary.
+5. Place shutdown logic so dependent resources are released safely.
+6. Keep subsystem-specific behavior inside the subsystem instead of adding unrelated logic to `main.cpp`.
+
+`main.cpp` should coordinate subsystem lifecycle order. It should not contain the internal implementation details of each subsystem.
+
+
 ## Who maintaining what
 
 | Subsystem | Owner      | Scope |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,6 @@ Every subsystem shall stay decoupled from everything else, on purpose. We don't 
 
 The main loop in main.cpp is the only place that knows about every subsystem at once, calling each one's init in dependency order at startup, update every frame, and shutdown in reverse order at the end.
 
-Every subsystem's architecture and patterns
 ---
 
 ## Subsystem Lifecycle
@@ -95,7 +94,7 @@ For example:
 * Configuration is initialized first because other parts of the engine read application configuration.
 * Time is initialized before entering the main loop.
 * The window is initialized before the renderer because rendering requires a valid windowing environment.
-* Audio is initialized after the renderer.
+* Audio is initialized after the core window and rendering systems are available.
 * Scene data is loaded after the core runtime systems are available.
 
 When adding a subsystem, determine its dependencies before choosing where its initialization belongs.
@@ -110,7 +109,7 @@ The current update order is:
 Time → Window → Renderer
 ```
 
-Conceptually, each frame performs:
+The current main loop performs:
 
 ```cpp
 while (clz::state::g_engineState != clz::state::EngineState::Shutdown)


### PR DESCRIPTION
## Closes #26

## Description

This PR adds dedicated subsystem lifecycle documentation for new contributors.

The documentation is based on the current lifecycle implementation in `src/main.cpp` and explains how Curloz Engine coordinates subsystem initialization, per-frame updates, and shutdown.

### Changes

* Added a high-level subsystem lifecycle overview.
* Documented the current initialization order.
* Documented the per-frame update sequence.
* Documented the current shutdown order.
* Added guidance on respecting subsystem boundaries.
* Added guidance for integrating future subsystems into the lifecycle.
* Included lifecycle flow diagrams and examples based on `src/main.cpp`.

### Why

The existing contributor guide explains the modular subsystem architecture, but the lifecycle flow was difficult to understand quickly.

This update gives new contributors a clear reference for:

* dependency-aware initialization;
* frame update responsibilities;
* safe shutdown ordering;
* subsystem ownership and separation of concerns.

## Screenshots
<img width="1257" height="931" alt="Screenshot 2026-07-04 151822" src="https://github.com/user-attachments/assets/13ae83de-bab9-47ca-af81-b4be916924c8" />

<img width="1268" height="937" alt="Screenshot 2026-07-04 151827" src="https://github.com/user-attachments/assets/0bdc42bd-1d50-4956-9d29-feed1cc4c2fe" />

<img width="1299" height="940" alt="Screenshot 2026-07-04 151834" src="https://github.com/user-attachments/assets/3b812fc7-c991-4d17-b25c-6afc74ab2d40" />

<img width="1326" height="950" alt="Screenshot 2026-07-04 151843" src="https://github.com/user-attachments/assets/b32ef9a1-fa2e-4378-b479-accbe22a4da2" />

<img width="1153" height="945" alt="Screenshot 2026-07-04 151901" src="https://github.com/user-attachments/assets/22ef5883-492f-40a0-8bfb-990151f2dd3b" />

### Testing

Documentation-only change.

* Verified lifecycle sequences against the current `src/main.cpp`.
* Reviewed Markdown structure and code blocks.
* Confirmed that the documented initialization, update, and shutdown flows match the current implementation.

### @curloz123 Kindly review my PR and merge it. 

**Jidnyasa Patil , ECSoC'26 Contributor**

