### PR TITLE
ci: add GitHub Actions workflow for automated build verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,13 @@ on:
 
 jobs:
   build:
-    name: Build Curloz Engine
-    runs-on: ubuntu-latest
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout repository
@@ -15,7 +20,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install dependencies
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt update
           sudo apt install -y \
@@ -25,8 +31,20 @@ jobs:
             vulkan-tools \
             libvulkan-dev
 
-      - name: Configure CMake
+      - name: Configure CMake (Linux)
+        if: runner.os == 'Linux'
         run: cmake -B build/debug -G Ninja
 
-      - name: Build
+      - name: Build (Linux)
+        if: runner.os == 'Linux'
+        run: cmake --build build/debug
+
+      - name: Configure CMake (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: cmake -B build/debug -G Ninja
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: cmake --build build/debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Build Verification
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build Curloz Engine
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            cmake \
+            ninja-build \
+            clang-format \
+            vulkan-tools \
+            libvulkan-dev
+
+      - name: Configure CMake
+        run: cmake -B build/debug -G Ninja
+
+      - name: Build
+        run: cmake --build build/debug


### PR DESCRIPTION
## Description

This PR introduces a GitHub Actions workflow to verify(automatically)  that the project builds successfully on every push and pull request.

### What was added

- Added a GitHub Actions workflow at `.github/workflows/ci.yml`
- Configured the workflow to run on every push and pull request
- Uses the project's documented CMake + Ninja build process from the README
- Checks out the repository along with all Git submodules
- Installs the required build dependencies
- Configures and builds the project using CMake

### Why

While exploring the repository, I noticed that the build process was well documented, but there was no CI workflow to automatically verify that new commits and pull requests build successfully.

Since the project uses Git submodules (such as GLFW, Assimp, OpenAL Soft, and ImGui), the workflow performs a recursive checkout to ensure all dependencies are available before configuring the project with CMake.

Adding this workflow helps to:

- Detect build regressions early
- Provide quick feedback to contributors
- Make pull request reviews easier
- Ensure the documented build process continues to work over time

Closes #36 