### PR TITLE
feature: add GitHub issue/PR templates and fix repo doc/config drift

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- **OS**: (e.g. Ubuntu 24.04, Windows 11)
+- **GPU + driver version**: (e.g. NVIDIA RTX 3060, driver 550.x)
+- **Vulkan SDK version**: run `vulkaninfo --summary` and paste the relevant output
+- **Compiler + version**: (e.g. Clang 18, MSVC 19.40)
+- **CMake version**: `cmake --version`
+- **Ninja version**: `ninja --version`
+
+> If this looks like a build/configure issue, please check the [Build Troubleshooting](../../README.md#build-troubleshooting) section of the README first.
+
+## Build Logs
+
+<details>
+<summary>Click to expand</summary>
+
+```text
+Paste relevant build/runtime logs here
+```
+
+</details>
+
+## Additional Context
+
+Add any other context, screenshots, or related issues here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Read the README
+    url: https://github.com/curl0z/curloz-engine/blob/main/README.md
+    about: Project overview, build instructions, and troubleshooting steps.
+  - name: Read the Contributing Guide
+    url: https://github.com/curl0z/curloz-engine/blob/main/CONTRIBUTING.md
+    about: Architecture, subsystem ownership, git workflow, and code style before you open an issue or PR.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature Request
+about: Suggest an idea or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem / Motivation
+
+What problem does this solve, or what's missing today? Why does it matter?
+
+## Proposed Solution
+
+Describe the change or feature you'd like to see.
+
+## Affected Subsystem
+
+Which subsystem(s) does this touch? (see the ownership table in [CONTRIBUTING.md](../../CONTRIBUTING.md#who-maintaining-what))
+
+- [ ] Window
+- [ ] Renderer
+- [ ] Math
+- [ ] ECS
+- [ ] Physics
+- [ ] Audio
+- [ ] Website / Documentation
+- [ ] Build System
+- [ ] Other (please specify)
+
+## Alternatives Considered
+
+Any alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context, mockups, or references here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Summary
+
+Describe what this PR does and why.
+
+## Related Issue
+
+Fixes #
+
+## Type of Change
+
+- [ ] feature — new functionality
+- [ ] fix — bug fix
+- [ ] refactor — code change with no behavior change
+- [ ] docs — documentation only
+
+## Subsystem(s) Touched
+
+Which subsystem(s) does this PR touch? (see the ownership table in [CONTRIBUTING.md](../CONTRIBUTING.md#who-maintaining-what))
+
+- [ ] Window
+- [ ] Renderer
+- [ ] Math
+- [ ] ECS
+- [ ] Physics
+- [ ] Audio
+- [ ] Website / Documentation
+- [ ] Build System
+- [ ] Other (please specify)
+
+## Checklist
+
+- [ ] Built locally (`cmake -B build/debug -G Ninja && cmake --build build/debug`)
+- [ ] Ran clang-format on changed files
+- [ ] Followed commit message format (`type: short description`)
+- [ ] Did not touch code outside my assigned subsystem without discussion first

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,7 @@ zipmaker.sh
 CurlozEngine.zip
 
 # shader binaries
-shader/triangle.vert.spirv
-shader/triangle.frag.spirv
+shaders/*.spirv
 
 # Test models
 assets/models/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,10 @@ find_package(Vulkan REQUIRED)
 ## Compile options
 
 # Compile Profile
-set(CMAKE_CONFIGURATION_TYPES "Debug;Sandbox;RelWithDebInfo;Release" CACHE STRING "" FORCE)
+set(CMAKE_CONFIGURATION_TYPES "Debug;Editor;RelWithDebInfo;Release" CACHE STRING "" FORCE)
 target_compile_definitions(${PROJECT_NAME} PRIVATE
-        $<$<CONFIG:Debug>:CLZ_DEBUG CLZ_ENABLE_SANDBOX CLZ_ENABLE_LOGS>
-        $<$<CONFIG:Sandbox>:CLZ_ENABLE_SANDBOX CLZ_ENABLE_LOGS>
+        $<$<CONFIG:Debug>:CLZ_DEBUG CLZ_ENABLE_EDITOR CLZ_ENABLE_LOGS>
+        $<$<CONFIG:Editor>:CLZ_ENABLE_EDITOR CLZ_ENABLE_LOGS>
         $<$<CONFIG:RelWithDebInfo>:CLZ_RELEASE CLZ_ENABLE_LOGS>
         $<$<CONFIG:Release>:CLZ_RELEASE>
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(Vulkan REQUIRED)
 ## Compile options
 
 # Compile Profile
-set(CMAKE_CONFIGURATION_TYPES "Debug;Editor;RelWithDebInfo;Release" CACHE STRING "" FORCE)
+set(CMAKE_CONFIGURATION_TYPES "Debug;Sandbox;RelWithDebInfo;Release" CACHE STRING "" FORCE)
 target_compile_definitions(${PROJECT_NAME} PRIVATE
         $<$<CONFIG:Debug>:CLZ_DEBUG CLZ_ENABLE_SANDBOX CLZ_ENABLE_LOGS>
         $<$<CONFIG:Sandbox>:CLZ_ENABLE_SANDBOX CLZ_ENABLE_LOGS>

--- a/README.md
+++ b/README.md
@@ -143,10 +143,11 @@ cmake --build build/debug
 curloz-engine/
 ├── src/                # Source files (.cpp)
 ├── include/            # Header files (.hpp)
+│   └── core/           # Utility functions, basically helpers used in entire engine
 ├── shaders/            # GLSL shaders, compiled to .spv
 ├── assets/             # Models, textures, audio
+├── config/             # Engine/scene configuration (engine.toml, scene.json)
 ├── external/           # Git submodules (do not modify manually)
-├── core/               # Utility functions, basically helpers used in entire engine
 ├── .clang-format       # clang-format configuration
 ├── .editorconfig       # editorconfig configuration
 ├── CMakeLists.txt      # CMake build configuration

--- a/include/core/enginestate.hpp
+++ b/include/core/enginestate.hpp
@@ -14,20 +14,20 @@ namespace clz::state
 	/**
 	 * @brief Describes current state of engine
 	 * Game means engine is in game mode
-	 * Editor means engine is in sandbox mode (Only Enabled when CLZ_ENABLE_SANDBOX is defined)
+	 * Editor means engine is in editor mode (Only Enabled when CLZ_ENABLE_EDITOR is defined)
 	 * Shutdown means, engine has to shut down
 	 */
 	enum class EngineState
 	{
 		Game,
-		Sandbox,
+		Editor,
 		Shutdown
 	};
 
 	/// @brief Global engine state. The engine will shut down once enum is set to
 	/// EngineState::Shutdown
-#ifdef CLZ_ENABLE_SANDBOX
-	inline EngineState g_engineState = EngineState::Sandbox;
+#ifdef CLZ_ENABLE_EDITOR
+	inline EngineState g_engineState = EngineState::Editor;
 #else
 	inline EngineState g_engineState = EngineState::Game;
 #endif
@@ -47,7 +47,7 @@ namespace clz::state
 			clz::log::info("Engine state set to Running by: " + std::string(callerLocation));
 			break;
 
-		case EngineState::Sandbox:
+		case EngineState::Editor:
 			clz::log::info("Engine state set to Editor by: " + std::string(callerLocation));
 			break;
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook for Curloz Engine.
+# Rejects the commit if any staged .cpp/.hpp/.h file doesn't match .clang-format.
+#
+# Install: cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+
+set -euo pipefail
+
+if ! command -v clang-format >/dev/null 2>&1; then
+	echo "pre-commit: clang-format not found on PATH, skipping style check" >&2
+	exit 0
+fi
+
+staged_files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.cpp' '*.hpp' '*.h')
+
+if [ -z "$staged_files" ]; then
+	exit 0
+fi
+
+failed=0
+
+while IFS= read -r file; do
+	[ -f "$file" ] || continue
+	if ! clang-format --dry-run --Werror "$file" >/dev/null 2>&1; then
+		echo "pre-commit: $file is not clang-format clean" >&2
+		failed=1
+	fi
+done <<< "$staged_files"
+
+if [ "$failed" -ne 0 ]; then
+	echo "" >&2
+	echo "Formatting check failed. Fix with:" >&2
+	echo "  find src include -name \"*.cpp\" -o -name \"*.hpp\" | xargs clang-format -i" >&2
+	exit 1
+fi
+
+exit 0

--- a/src/renderer/camera/camera.cpp
+++ b/src/renderer/camera/camera.cpp
@@ -13,7 +13,7 @@ namespace clz::renderer::camera
 {
 	void setActiveCamera(const CameraID id)
 	{
-#ifdef CLZ_ENABLE_SANDBOX
+#ifdef CLZ_ENABLE_EDITOR
 		const auto previousActiveCamera = activeCamera;
 		if (id == EditorCam && previousActiveCamera == GameCam)
 		{
@@ -41,7 +41,7 @@ namespace clz::renderer::camera
 			return false;
 		}
 
-#ifdef CLZ_ENABLE_SANDBOX
+#ifdef CLZ_ENABLE_EDITOR
 		if (!loadCamera("editor", EditorCam))
 		{
 			clz::log::error("Could not load editor camera");

--- a/src/renderer/camera/camerafunctions.cpp
+++ b/src/renderer/camera/camerafunctions.cpp
@@ -120,7 +120,7 @@ namespace clz::renderer::camera
 			FirstTime[id] = false;
 		}
 
-		if (state::g_engineState == state::EngineState::Sandbox && !window::isMousePressed(input::Mouse::MouseRight))
+		if (state::g_engineState == state::EngineState::Editor && !window::isMousePressed(input::Mouse::MouseRight))
 		{
 			LastX[id] = xPos;
 			LastY[id] = yPos;

--- a/src/renderer/editor/editor.cpp
+++ b/src/renderer/editor/editor.cpp
@@ -2,7 +2,7 @@
  * @file editor.cpp
  * @author curl0z
  *
- * @brief Sandbox editor implementation
+ * @brief Editor implementation
  */
 
 #include "renderer/editor/editor.hpp"

--- a/src/renderer/mainloop.cpp
+++ b/src/renderer/mainloop.cpp
@@ -21,15 +21,15 @@ namespace clz::renderer
 {
 	void render(VkCommandBuffer commandBuffer, const uint32_t currentFrame)
 	{
-#ifdef CLZ_ENABLE_SANDBOX
+#ifdef CLZ_ENABLE_EDITOR
 		if (window::isKeyPressed(input::Key::Escape) && state::g_engineState == state::EngineState::Game)
 		{
 			window::enableCursor();
 			camera::setActiveCamera(camera::EditorCam);
-			setEngineState(state::EngineState::Sandbox, "KEY->ESCAPE, mid render loop");
+			setEngineState(state::EngineState::Editor, "KEY->ESCAPE, mid render loop");
 		}
 		if (window::isKeyPressed(input::Key::LeftControl) && window::isKeyPressed(input::Key::G) &&
-		    state::g_engineState == state::EngineState::Sandbox)
+		    state::g_engineState == state::EngineState::Editor)
 		{
 			window::disableCursor();
 			camera::setActiveCamera(camera::GameCam);
@@ -43,8 +43,8 @@ namespace clz::renderer
 		updateShaderData(commandBuffer, currentFrame);
 		drawEntitiesMainPipeline(commandBuffer);
 
-#ifdef CLZ_ENABLE_SANDBOX
-		if (state::g_engineState == state::EngineState::Sandbox)
+#ifdef CLZ_ENABLE_EDITOR
+		if (state::g_engineState == state::EngineState::Editor)
 			editor::update(commandBuffer);
 #endif
 	}

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -63,7 +63,7 @@ namespace clz::renderer
 
 		clz::log::info("initialized all renderer context's");
 
-#ifdef CLZ_ENABLE_SANDBOX
+#ifdef CLZ_ENABLE_EDITOR
 		if (!editor::init())
 		{
 			clz::log::error("Could not initialize editor");

--- a/src/scene/entity/entity.cpp
+++ b/src/scene/entity/entity.cpp
@@ -63,7 +63,7 @@ namespace clz::ecs
 			if (entityData.contains("transform"))
 			{
 				addComponent<TransformComponent>(e, retrieveTransformComponent(entityData["transform"]));
-#ifdef CLZ_ENABLE_SANDBOX
+#ifdef CLZ_ENABLE_EDITOR
 				addComponent<EulerRotationComponent>(e, {math::quatToEulerXYZ(getComponent<TransformComponent>(e).rotation)});
 #endif
 			}

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -28,7 +28,7 @@ namespace clz::window
 		glfwSetScrollCallback(w_window, scrollCallback);
 
 		// Cursor's initial state
-#ifdef CLZ_ENABLE_SANDBOX
+#ifdef CLZ_ENABLE_EDITOR
 		enableCursor();
 #else
 		disableCursor();


### PR DESCRIPTION
- Add `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md` to standardize issue reports (repro steps, expected/actual, OS/GPU/Vulkan SDK version, build logs, affected subsystem)
- Add `.github/ISSUE_TEMPLATE/config.yml` linking back to README/CONTRIBUTING instead of a blank issue form
- Add `.github/PULL_REQUEST_TEMPLATE.md` with a summary/checklist section (build locally, clang-format, commit message format, subsystem ownership)
- Add `scripts/pre-commit`, a clang-format check hook — CONTRIBUTING.md already told contributors to `cp scripts/pre-commit .git/hooks/pre-commit`, but the file never existed
- Fix `CMakeLists.txt`: `CMAKE_CONFIGURATION_TYPES` listed `Editor`, but the `$<CONFIG:...>` generator expression checks `Sandbox` (the actual `EngineState::Sandbox` used throughout the renderer/camera code) — `Editor` was dead and `Sandbox` was unselectable in multi-config generators like Visual Studio
- Fix `.gitignore`: shader binary pattern was `shader/*.spirv` (directory doesn't exist); real directory is `shaders/`, so compiled `.spv`/`.spirv` binaries were never actually ignored
- Fix `README.md` "Project Structure": `core/` is nested under `include/`, not top-level, and `config/` (`engine.toml`, `scene.json`) was missing from the tree entirely

## Why

Standardizes contributions, reduces back-and-forth on incomplete reports, and fixes a handful of doc/build-config inconsistencies that trip up new contributors — especially relevant with the influx of first-time contributors during ECSoC26. Pairs naturally with the build-verification workflow proposed in #36.

Fixes #<issue-number>
